### PR TITLE
Fix scheduling with wait

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,6 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 # Specify your gem's dependencies in rails_async_methods.gemspec.
 gemspec
 
-gem "pg"
 gem 'delayed_job_active_record'
 gem 'daemons'
 

--- a/lib/rails_async_methods/active_job_options_parser.rb
+++ b/lib/rails_async_methods/active_job_options_parser.rb
@@ -9,7 +9,7 @@ module RailsAsyncMethods
       @prefix = method_prefix(opts[:prefix])
       @queue = opts[:queue]
       @wait_until = opts[:wait_until].to_f if opts[:wait_until]
-      @wait = opts[:wait].seconds.from_now.to_f if opts[:wait]
+      @wait = opts[:wait].seconds.to_f if opts[:wait]
       @priority = opts[:priority].to_i if opts[:priority]
       @job = get_job_obj(opts[:job])
     end

--- a/rails_async_methods.gemspec
+++ b/rails_async_methods.gemspec
@@ -5,9 +5,9 @@ Gem::Specification.new do |spec|
   spec.version     = RailsAsyncMethods::VERSION
   spec.authors     = ["benngarcia"]
   spec.email       = ["beng4606@gmail.com"]
-  spec.homepage      = "https://github.com/benngarcia/rails_async_methods"
-  spec.summary       = "Quickly, create async callers and receivers for your rails methods, because y'know DRY."
-  spec.description   = "Utilizes the ActiveJob api to provide async callers and receivers without duplicating code."
+  spec.homepage    = "https://github.com/benngarcia/rails_async_methods"
+  spec.summary     = "Quickly, create async callers and receivers for your rails methods, because y'know DRY."
+  spec.description = "Utilizes the ActiveJob api to provide async callers and receivers without duplicating code."
   spec.license     = "MIT"
 
   spec.metadata["homepage_uri"] = spec.homepage
@@ -17,10 +17,10 @@ Gem::Specification.new do |spec|
     Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.md"]
   end
 
-  spec.add_dependency "rails", ">= 7.0.2.4"
   spec.add_dependency "activesupport"
-  spec.add_development_dependency 'minitest'
-  spec.add_development_dependency 'pg'
-  spec.add_development_dependency 'pry'
-  spec.add_development_dependency 'sidekiq'
+  spec.add_dependency "rails", ">= 7.0.2.4"
+  spec.add_development_dependency "minitest"
+  spec.add_development_dependency "pg"
+  spec.add_development_dependency "pry"
+  spec.add_development_dependency "sidekiq"
 end

--- a/test/async_method_rails_test.rb
+++ b/test/async_method_rails_test.rb
@@ -57,7 +57,7 @@ class RailsAsyncMethodsTest < ActiveSupport::TestCase
     ex = AsyncExample.create!
     dj = ex.async_method_with_diff_wait_time_and_priority
 
-    assert_in_epsilon dj.scheduled_at, 1.week.from_now.to_i, 60
+    assert_in_delta dj.scheduled_at, 1.week.from_now.to_i, 60
     assert_equal dj.priority, -10
   end
 
@@ -120,7 +120,7 @@ class RailsAsyncMethodsTest < ActiveSupport::TestCase
     assert_equal dj.queue_name, 'fast'
     assert_equal dj.class, ExampleCustomAsyncJob
     assert_not_nil ex.reload.testfield
-    assert_in_epsilon dj.scheduled_at, 1.week.from_now.to_i, 60
+    assert_in_delta dj.scheduled_at, 1.week.from_now.to_i, 60
     run_last
     assert_nil ex.reload.testfield
   end
@@ -132,5 +132,4 @@ class RailsAsyncMethodsTest < ActiveSupport::TestCase
 
     assert_equal ex.reload.testfield, '[2, 3, 4]'
   end
-
 end


### PR DESCRIPTION
There is a bug when calling async with `wait`.
Instead of waiting 1 hour we wait 53 years because `from_now` is used in `opts[:wait].seconds.from_now.to_f`.

The test were passing because `assert_in_epsilon` was used instead of `assert_in_delta` which allows a difference of the minimum value times epsilon (https://apidock.com/ruby/v1_9_3_392/MiniTest/Assertions/assert_in_epsilon)